### PR TITLE
Removing BinaryProvider from dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Shinya Kouketsu <shinya.kouketsu@gmail.com>", "Alexander Barth <bart
 version = "0.1.1"
 
 [deps]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+#BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 GibbsSeaWater_jll = "6727f6b2-98ea-5d0a-8239-2f72283ddb11"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
Everything is now working on Apple Silicon Macs! The only error it threw was about BinaryProvider.jl. The BinaryProvider dependency does not seem to be needed so I removed it from the Project.toml file.