### PR TITLE
bump version to 0.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GibbsSeaWater"
 uuid = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
 authors = ["Shinya Kouketsu <shinya.kouketsu@gmail.com>", "Alexander Barth <barth.alexander@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 #BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"


### PR DESCRIPTION
new minor version release for #20 (and probably other fixes too [[see diff](https://github.com/TEOS-10/GibbsSeaWater.jl/compare/v0.1.1...master)]).

Closes #22 